### PR TITLE
Do not create NickColorGenerator if "coloroverride" attribute == "true"

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -257,7 +257,9 @@ Textual.newMessagePostedToView = function (line) {
   // if it's a private message, colorize the nick and then track the state and fade away the nicks if needed
   if (message.getAttribute('ltype') === 'privmsg' || message.getAttribute('ltype') === 'action') {
     sender = message.getElementsByClassName('sender')[0];
-    new NickColorGenerator(message); // colorized the nick
+    if (sender.getAttribute('coloroverride') !== 'true') {
+        new NickColorGenerator(message); // colorized the nick
+    }
 
     // Delete (ie, make foreground and background color identical) the previous line's nick, if it was set to be deleted
     if (rs.nick.delete === true) {


### PR DESCRIPTION
coloroverride=true is set when the following conditions are met:
1. User is using new coloring system which uses style= attribute to
define color, not colornumber=
2. User has defined a custom color for a user which NickColorGenerator
would otherwise override