### PR TITLE
Define CSS when body[customscroller="true"]

### DIFF
--- a/design.css
+++ b/design.css
@@ -14,7 +14,7 @@ body {
   background-color: #1d1d1d;
   font-family: "Helvetica Neue";
   font-weight: 200;
-  overflow-y: visible;
+  overflow-y: auto;
 }
 
 p {
@@ -48,6 +48,29 @@ body[dir=rtl] .senderContainer {
 /* Hide some internal stuff. */
 #timestampWidth {
   display: none;
+}
+
+/* Scrolling */
+
+body[customscroller="true"]::-webkit-scrollbar {
+  width: 17px;
+}
+
+body[customscroller="true"]::-webkit-scrollbar-track {
+  background: #393939;
+  box-shadow: inset 1px 0px 0px 0px #4b4b4b;
+}
+
+body[customscroller="true"]::-webkit-scrollbar-thumb {
+  background-color: #7c7c7c;
+  border: 4px solid transparent;
+  border-left: 5px solid transparent;
+  border-radius: 20px;
+  background-clip: content-box;
+}
+
+body[customscroller="true"]::-webkit-scrollbar-thumb:hover {
+  background-color: #b0b0b0;
 }
 
 /* Loading Screen */


### PR DESCRIPTION
WebKit2 does not have a way to have its scrollbar set to dark. So that
a white scrollbar does not stick out like a sore thumb, the
“customscroller” attribute is used as an indicator that a style should
use a custom scroller.

This commit introduces CSS that recreates the standard OS X scrollbar,
but darker.