### PR TITLE
Do not override Textual.notifyDidBecomeVisible()

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -441,6 +441,12 @@ Textual.viewBodyDidLoad = function () {
   setTimeout(function () {
     Textual.scrollToBottomOfView();
   }, 500);
+  
+  /* Disable date changes on OS X Mountain Lion because WebKit does not have some of
+     the features that this feature depends on (e.g. -webkit-flex) */
+  if (document.documentElement.getAttribute("systemversion").indexOf("10.8.") === 0) {
+    Equinox.showDateChanges = false;
+  }
 };
 
 Textual.viewInitiated = function () {

--- a/scripts.js
+++ b/scripts.js
@@ -434,12 +434,6 @@ Textual.nicknameSingleClicked = function (e) {
   }
 };
 
-/* Don't jump back to the bottom of the window when the view becomes visible */
-Textual.notifyDidBecomeVisible = function () {
-  'use strict';
-  window.getSelection().empty();
-};
-
 Textual.viewBodyDidLoad = function () {
   'use strict';
   Textual.fadeOutLoadingScreen(1.00, 0.95);


### PR DESCRIPTION
This function no longer performs auto scrolling to the bottom (which is
the original reason an override was added)

Removing it fixes the incorrect behavior being inherited in Textual 6