### PR TITLE
Add "Channel View Overlay Color" setting to styleSettings.plist

### DIFF
--- a/Data/Settings/styleSettings.plist
+++ b/Data/Settings/styleSettings.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>Channel View Overlay Color</key>
+	<string>#00000066</string>
 	<key>Nickname Format</key>
 	<string>%@%n</string>
  	<key>Nickname Color Style</key>


### PR DESCRIPTION
When you select multiple channels in Textual 6, the channel that is not
frontmost has an overlay view which is a style defined color.

The color is defined in #RRGGBBAA format

This commit defines Equinox’s color as black with 0.4 alpha